### PR TITLE
Bug 1090689 - Add MPL2.0 headers to the repo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 language: node_js
 node_js:
 - '0.10'

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
+
 module.exports = function(grunt) {
   var docFiles = [
     'README.md',
@@ -6,7 +10,7 @@ module.exports = function(grunt) {
     'factory/github.js'
   ];
 
-  
+
   // Project configuration.
   grunt.initConfig({
     pkg: grunt.file.readJSON('package.json'),

--- a/bin/treeherder
+++ b/bin/treeherder
@@ -1,5 +1,9 @@
 #! /usr/bin/env node
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 var Github = require('github');
 var program = require('commander');
 var URL = require('url');

--- a/consts.js
+++ b/consts.js
@@ -1,6 +1,8 @@
-/**
-Defaults for the treeherder service.
-*/
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// Defaults for the treeherder service
 module.exports = {
   baseUrl: process.env.TREEHERDER_URL ||
            'http://treeherder-dev.allizom.org/api/'

--- a/factory/github.js
+++ b/factory/github.js
@@ -1,7 +1,11 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
+
 /**
 @fileoverview
 
-Github factory which will convert github results into treeherder compatible 
+Github factory which will convert github results into treeherder compatible
 types.
 
 @module mozilla-treeherder/factory/github

--- a/factory/github_test.js
+++ b/factory/github_test.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
+
 suite('github', function() {
   var REPO = 'gaia';
 

--- a/github.js
+++ b/github.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
+
 /**
 @fileoverview
 

--- a/github_test.js
+++ b/github_test.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
+
 suite('github', function() {
   var nock = require('nock');
   var subject = require('./github');

--- a/httperror.js
+++ b/httperror.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
+
 /**
 @fileoverview
 

--- a/httperror_test.js
+++ b/httperror_test.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
+
 suite('httperror', function() {
   var HttpError = require('./httperror');
   var fixture = require('./test/fixtures/error_body');

--- a/project.js
+++ b/project.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
+
 /**
 @module mozilla-treeherder/project
 */

--- a/project_test.js
+++ b/project_test.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
+
 suite('project', function() {
   var PROJECT_NAME = 'gaia';
 

--- a/test/github_nock.js
+++ b/test/github_nock.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
+
 var nock = require('nock');
 
 nock('https://api.github.com:443')

--- a/test/helper.js
+++ b/test/helper.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
+
 global.assert = require('assert');
 
 // Default url exported by the vagrant treeherder image.


### PR DESCRIPTION
This work fixes part 4 of Bugzilla bug [1090689](https://bugzilla.mozilla.org/show_bug.cgi?id=1090689).

This adds missing MPL2.0 headers to files in the treeherder-node repo, in its new repo location under `/mozilla`. There were a couple of empty white space corrections and a bit of tidy up along the way.

Adding @maurodoglio for review.
