### PR TITLE
Supplemental link updates after move to Mozilla Github organization

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,9 @@ deploy:
   access_key_id: AKIAJRL3G6MJIOJSMUFA
   secret_access_key:
     secure: YZHMzrBOkfeImHz8ZKeGwDCHd1FDi+YwwSHDSy0o8Rck15bqJXEO8FhN+Di/+zJNHiPxMa0xZtHmPQZuRRkrNjkvEbuCKQD/LR0fQhGmE7CTAaWLZJTUaU8+JYRt+1f3KxfTV5BG0pFWxLBaX3/ERc5PWyv1liBuEq2TZuzfLBw=
-  bucket: lightsofapollo-oss
+  bucket: mozilla-oss
   local-dir: doc
   upload-dir: mozilla-treeherder
   skip_cleanup: true
   on:
-    repo: lightsofapollo/treeherder-node
+    repo: mozilla/treeherder-node


### PR DESCRIPTION
This change makes a couple of additional updates, post treeherder-node move to Mozilla this morning. The changes are supplemental to those done already by Ed in https://github.com/mozilla/treeherder-node/commit/c7ffe69a6593353a17bebab9a2d93aafae4d4732.

I am assuming the `secret_access_key` doesn't have to change here.

nb. we have decided also to leave James as the repo Author in the package.json file:
`./package.json:  "author": "James Lal [:lightsofapollo]"`

Adding @lightsofapollo for review.
