### PR TITLE
Bug 1191403 - Add a User Agent to requests made to Treeherder

### DIFF
--- a/consts.js
+++ b/consts.js
@@ -2,8 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
 
+var packageInfo = require('./package.json');
+
 // Defaults for the treeherder service
 module.exports = {
+  userAgent: 'treeherder-nodeclient/' + packageInfo.version,
   baseUrl: process.env.TREEHERDER_URL ||
            'https://treeherder-dev.allizom.org/api/'
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mozilla-treeherder",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Treeherder client for mozilla's test reporting UI",
   "main": "project.js",
   "bin": {

--- a/project.js
+++ b/project.js
@@ -28,6 +28,7 @@ function buildRequest(credentials, user, method, url, body) {
 
   var header = hawk.client.header(url, method.toUpperCase(), payload);
   var req = request(method, url).
+    set('User-Agent', consts.userAgent).
     set('Content-Type', 'application/json').
     set('Authorization', header.field).
     send(body);
@@ -166,6 +167,9 @@ Project.prototype = {
     return request(
       method,
       this.url + path
+    ).set(
+      'User-Agent',
+      consts.userAgent
     ).end();
   },
 


### PR DESCRIPTION
The Python client's user agent is 'treeherder-pyclient/...', so I've chosen 'treeherder-nodeclient/...' for consistency.
